### PR TITLE
Mark as @inlinable to reduce actual function call

### DIFF
--- a/Pod/Classes/※ikemen.swift
+++ b/Pod/Classes/※ikemen.swift
@@ -4,7 +4,7 @@ precedencegroup IkemenPrecedence {
     higherThan: AssignmentPrecedence
 }
 
-public func ※<T>(value: T, modifier: (inout T) -> ()) -> T {
+@inlinable public func ※<T>(value: T, modifier: (inout T) -> ()) -> T {
     var v = value
     modifier(&v)
     return v


### PR DESCRIPTION
when function has `@inlinable` attribute, Swift compiler may try to inlining function call.

e.g. this Swift file:
```swift
import Ikemen

let str = "a" ※ { s in
	puts(s)
}
```
in current version of Ikemen, Swift compiler outputs this IR code (command: `swiftc -emit-ir -Osize -framework Ikemen -F ./ main.swift`):
```
; Function Attrs: minsize optsize
define i32 @main(i32 %0, i8** nocapture readnone %1) #0 {
entry:
  %2 = alloca %TSS, align 8
  %3 = bitcast %TSS* %2 to i8*
  call void @llvm.lifetime.start.p0i8(i64 16, i8* nonnull %3)
  %._guts._object._countAndFlagsBits._value = getelementptr inbounds %TSS, %TSS* %2, i64 0, i32 0, i32 0, i32 0, i32 0
  store i64 97, i64* %._guts._object._countAndFlagsBits._value, align 8
  %._guts._object._object = getelementptr inbounds %TSS, %TSS* %2, i64 0, i32 0, i32 0, i32 1
  store %swift.bridge* inttoptr (i64 -2233785415175766016 to %swift.bridge*), %swift.bridge** %._guts._object._object, align 8
  %4 = bitcast %TSS* %2 to %swift.opaque*
  call swiftcc void @"$s6Ikemen003dwgoiyxx_yxzXEtlF"(%swift.opaque* noalias nocapture sret(%swift.opaque) bitcast (%TSS* @"$s4main3strSSvp" to %swift.opaque*), %swift.opaque* noalias nocapture nonnull %4, i8* bitcast (void (%TSS*)* @"$s4mainySSzXEfU_" to i8*), %swift.opaque* null, %swift.type* nonnull @"$sSSN")
  call void @llvm.lifetime.end.p0i8(i64 16, i8* nonnull %3)
  ret i32 0
}

; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1

; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1

; Function Attrs: minsize optsize
define internal swiftcc void @"$s4mainySSzXEfU_"(%TSS* nocapture readonly dereferenceable(16) %0) #0 {
entry:
  %._guts._object._countAndFlagsBits._value = getelementptr inbounds %TSS, %TSS* %0, i64 0, i32 0, i32 0, i32 0, i32 0
  %1 = load i64, i64* %._guts._object._countAndFlagsBits._value, align 8
  %._guts._object._object = getelementptr inbounds %TSS, %TSS* %0, i64 0, i32 0, i32 0, i32 1
  %2 = load %swift.bridge*, %swift.bridge** %._guts._object._object, align 8
  %3 = tail call swiftcc %Ts28__ContiguousArrayStorageBaseC* @"$sSS11utf8CStrings15ContiguousArrayVys4Int8VGvg"(i64 %1, %swift.bridge* %2)
  %4 = getelementptr inbounds %Ts28__ContiguousArrayStorageBaseC, %Ts28__ContiguousArrayStorageBaseC* %3, i64 1
  %5 = bitcast %Ts28__ContiguousArrayStorageBaseC* %4 to i8*
  %6 = tail call i32 @puts(i8* nonnull %5)
  %7 = getelementptr %Ts28__ContiguousArrayStorageBaseC, %Ts28__ContiguousArrayStorageBaseC* %3, i64 0, i32 0
  tail call void @swift_release(%swift.refcounted* %7) #3
  ret void
}

; Function Attrs: minsize optsize
declare swiftcc void @"$s6Ikemen003dwgoiyxx_yxzXEtlF"(%swift.opaque* noalias nocapture sret(%swift.opaque), %swift.opaque* noalias nocapture, i8*, %swift.opaque*, %swift.type*) local_unnamed_addr #0
```

but with `@inlinable`, Swift compiler inlining ※ function and closure's body (!)
```
; Function Attrs: minsize optsize
define i32 @main(i32 %0, i8** nocapture readnone %1) #0 {
entry:
  %2 = tail call swiftcc %Ts28__ContiguousArrayStorageBaseC* @"$sSS11utf8CStrings15ContiguousArrayVys4Int8VGvg"(i64 97, %swift.bridge* nonnull inttoptr (i64 -2233785415175766016 to %swift.bridge*))
  %3 = getelementptr inbounds %Ts28__ContiguousArrayStorageBaseC, %Ts28__ContiguousArrayStorageBaseC* %2, i64 1
  %4 = bitcast %Ts28__ContiguousArrayStorageBaseC* %3 to i8*
  %5 = tail call i32 @puts(i8* nonnull %4)
  %6 = getelementptr %Ts28__ContiguousArrayStorageBaseC, %Ts28__ContiguousArrayStorageBaseC* %2, i64 0, i32 0
  tail call void @swift_release(%swift.refcounted* %6) #2
  store i64 97, i64* getelementptr inbounds (%TSS, %TSS* @"$s4main3strSSvp", i64 0, i32 0, i32 0, i32 0, i32 0), align 8
  store %swift.bridge* inttoptr (i64 -2233785415175766016 to %swift.bridge*), %swift.bridge** getelementptr inbounds (%TSS, %TSS* @"$s4main3strSSvp", i64 0, i32 0, i32 0, i32 1), align 8
  ret i32 0
}
```